### PR TITLE
Clarification around Datagrams

### DIFF
--- a/draft-jholland-quic-multicast.md
+++ b/draft-jholland-quic-multicast.md
@@ -1005,8 +1005,12 @@ For this situation, note that the Session ID is a variable length integer, and t
 
 ### Datagrams
 
-DATAGRAM frames ({{RFC9221}}) can be carried in multicast channels, and can be a good way to deliver popular content to receivers.
-Doing so can align well with existing multicast UDP-based applications, since a datagram API in a QUIC application offers similar functionality to a UDP API for sending and receiving packets.
+DATAGRAM frames in channel packets are subject to the max_datagram_frame_size transport parameter defined in {{RFC9221}} on the associated QUIC connection.
+A server MUST NOT send DATAGRAM frames in channel packets unless the client advertised max_datagram_frame_size
+with a non-zero value.
+A server MUST NOT send a DATAGRAM frame in a channel packet if the DATAGRAM frame is larger than the value advertised by the client.
+
+Using DATAGRAM frames can align well with existing multicast UDP-based applications, since a datagram API in a QUIC application offers similar functionality to a UDP API for sending and receiving packets.
 
 However, at the time of this writing (version -05 of {{I-D.draft-ietf-masque-h3-datagram}}) multicast channels generally cannot deliver HTTP/3 datagrams, including WebTransport datagrams (version -02 of {{I-D.draft-ietf-webtrans-http3}}), since the demuxing of WebTransport datagrams uses a Session ID based on a client-specific value (the HTTP/3 Session ID comes from the Stream ID of the client-initiated stream that issued the initial extended CONNECT request).
 

--- a/draft-jholland-quic-multicast.md
+++ b/draft-jholland-quic-multicast.md
@@ -1006,8 +1006,7 @@ For this situation, note that the Session ID is a variable length integer, and t
 ### Datagrams
 
 DATAGRAM frames in channel packets are subject to the max_datagram_frame_size transport parameter defined in {{RFC9221}} on the associated QUIC connection.
-A server MUST NOT send DATAGRAM frames in channel packets unless the client advertised max_datagram_frame_size
-with a non-zero value.
+A server MUST NOT send DATAGRAM frames in channel packets unless the client advertised max_datagram_frame_size with a non-zero value.
 A server MUST NOT send a DATAGRAM frame in a channel packet if the DATAGRAM frame is larger than the value advertised by the client.
 
 Using DATAGRAM frames can align well with existing multicast UDP-based applications, since a datagram API in a QUIC application offers similar functionality to a UDP API for sending and receiving packets.

--- a/draft-jholland-quic-multicast.md
+++ b/draft-jholland-quic-multicast.md
@@ -1005,9 +1005,11 @@ For this situation, note that the Session ID is a variable length integer, and t
 
 ### Datagrams
 
-DATAGRAM frames in channel packets are subject to the max_datagram_frame_size transport parameter defined in {{RFC9221}} on the associated QUIC connection.
-A server MUST NOT send DATAGRAM frames in channel packets unless the client advertised max_datagram_frame_size with a non-zero value.
-A server MUST NOT send a DATAGRAM frame in a channel packet if the DATAGRAM frame is larger than the value advertised by the client.
+DATAGRAM frames in channel packets are subject to the max_datagram_frame_size transport parameter defined in {{RFC9221}} on each associated QUIC connection.
+A server MUST NOT send MC_JOIN to a client for a channel that carries DATAGRAM frames unless that client advertised max_datagram_frame_size with a non-zero value.
+
+A server MUST NOT send MC_JOIN to a client for a channel if the server expects that channel to carry DATAGRAM frames larger than the max_datagram_frame_size value advertised by that client.
+If the server later sends larger DATAGRAM frames on that channel, clients whose advertised max_datagram_frame_size is exceeded will process this as specified by {{RFC9221}}, which can result in termination of their associated QUIC connections.
 
 Using DATAGRAM frames can align well with existing multicast UDP-based applications, since a datagram API in a QUIC application offers similar functionality to a UDP API for sending and receiving packets.
 


### PR DESCRIPTION
This is minor but closes #138.

I dont think max_datagram_frame_size belongs into MC_ANNOUNCE as:

1.: There is nothing the client can do with this information
2.: The max_datagram_frame_size tp is only about what the implementation supports; that is the same independent of delivery path 
3.: If the server violates max_datagram_frame_size with a DATAGRAM on a multicast channel, the client should still just follow section 3 of 9221 and terminate the connection; Once again delivery path doesn't play a role 